### PR TITLE
refactor!: Rename main function to `check_email`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ tab_width=4
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
-max_line_length=120
+max_line_length=80
 insert_final_newline=true
 
 [*.{yml,sh}]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 
-name: pr
+name: CI
 
 on: [pull_request]
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,11 @@ jobs:
           command: check
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -41,21 +45,6 @@ jobs:
         with:
           command: test
           args: --all
-
-  e2e:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
-    steps:
-      - uses: hecrj/setup-rust-action@v1
-
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Run tests
-        run: cargo run -- someone@gmail.com | grep "is_deliverable" # If `is_deliverable` shows up, it means that the SMTP checks happened
 
   lints:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 **/*.rs.bk
 .DS_Store
+
+# sensitive data
+/test_suite/src/sensitive_fixtures/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "check-if-email-exists"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "amaurymartiny-async-smtp",
  "fast-socks5",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "check-if-email-exists-cli"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "check-if-email-exists",
  "clap",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "check-if-email-exists-test-suite"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "check-if-email-exists",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-if-email-exists-cli"
-version = "0.7.1"
+version = "0.8.0"
 default-run = "check_if_email_exists"
 edition = "2018"
 license = "GPL-3.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 # `ciee` stands for check-if-email-exists
 WORKDIR /ciee
 # Fetch latest version
-ENV CIEE_VERSION 0.7.1
+ENV CIEE_VERSION 0.8.0
 
 # Install needed libraries
 RUN apk update && \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Optionally, you can also pass in `from_email` and `hello_name` fields into the J
 **💡 PRO TIP:** To show debug logs when running the binary, run:
 
 ```bash
-RUST_LOG=check-if-email-exists check_if_email_exists [FLAGS] [OPTIONS] [TO_EMAIL]
+RUST_LOG=debug check_if_email_exists [FLAGS] [OPTIONS] [TO_EMAIL]
 ```
 
 ### 4. Usage as a Rust Library

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The output will be a JSON with the below format, the fields should be self-expla
 }
 ```
 
-You can also take a look at the [OpenAPIv3 specification](https://stoplight.io/p/docs/gh/reacherhq/openapi/openapi.json/components/schemas/EmailResult?srn=gh/reacherhq/openapi/openapi.json/components/schemas/EmailResult) of this JSON object.
+You can also take a look at the [OpenAPIv3 specification](https://stoplight.io/p/docs/gh/reacherhq/openapi/openapi.json/components/schemas/EmailResult?srn=gh/reacherhq/backend/openapi.json/components/schemas/EmailResult) of this JSON object.
 
 ## ❓ FAQ
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Optionally, you can also pass in `from_email` and `hello_name` fields into the J
 **💡 PRO TIP:** To show debug logs when running the binary, run:
 
 ```bash
-RUST_LOG=debug check_if_email_exists [FLAGS] [OPTIONS] [TO_EMAIL]
+RUST_LOG=check-if-email-exists check_if_email_exists [FLAGS] [OPTIONS] [TO_EMAIL]
 ```
 
 ### 4. Usage as a Rust Library

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,16 +11,15 @@ main() {
         return
     fi
 
-    cross test --all --target $TARGET
-    cross test --all --target $TARGET --release
-
-    # Run the binary with a $TEST_EMAIL, to test that the tool actually works.
-    # aka some quick e2e test on the binary itself
-    # TODO This only works on osx now, see #11
+    # FIXME This only works on osx now
+    # See https://github.com/amaurymartiny/check-if-email-exists/issues/11
     if [ $TRAVIS_OS_NAME = osx ]; then
-        cross run --target $TARGET $TEST_EMAIL | grep "\"is_deliverable\": true"
-        cross run --target $TARGET --release $TEST_EMAIL | grep "\"is_deliverable\": true"
+        cross test --all --target $TARGET
+        cross test --all --target $TARGET --release
     fi
+
+    cross run --target $TARGET
+    cross run --target $TARGET --release
 }
 
 # we don't run the "test phase" when doing deploys

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-if-email-exists"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Amaury Martiny <amaury.martiny@protonmail.com>"]
 categories = ["email"]
 description = "Check if an email address exists without sending any email"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -72,6 +72,7 @@ use serde::{ser::SerializeMap, Serialize, Serializer};
 use smtp::{check_smtp, SmtpDetails, SmtpError};
 use std::str::FromStr;
 use syntax::{check_syntax, SyntaxDetails};
+use util::constants::LOG_TARGET;
 
 pub use util::input::*;
 
@@ -139,7 +140,7 @@ async fn check_single_email(input: CheckEmailInput) -> CheckEmailResult {
 
 	let to_email = &input.to_emails[0];
 
-	debug!("Checking email \"{}\"", to_email);
+	debug!(target: LOG_TARGET, "Checking email \"{}\"", to_email);
 	let my_syntax = check_syntax(to_email.as_ref());
 	if !my_syntax.is_valid_syntax {
 		return CheckEmailResult {
@@ -151,7 +152,10 @@ async fn check_single_email(input: CheckEmailInput) -> CheckEmailResult {
 		};
 	}
 
-	debug!("Found the following syntax validation: {:?}", my_syntax);
+	debug!(
+		target: LOG_TARGET,
+		"Found the following syntax validation: {:?}", my_syntax
+	);
 
 	let my_mx = match check_mx(&my_syntax).await {
 		Ok(m) => m,
@@ -165,7 +169,10 @@ async fn check_single_email(input: CheckEmailInput) -> CheckEmailResult {
 			}
 		}
 	};
-	debug!("Found the following MX hosts {:?}", my_mx);
+	debug!(
+		target: LOG_TARGET,
+		"Found the following MX hosts {:?}", my_mx
+	);
 
 	// Return if we didn't find any MX records.
 	if my_mx.lookup.is_err() {
@@ -185,7 +192,10 @@ async fn check_single_email(input: CheckEmailInput) -> CheckEmailResult {
 			.expect("We already checked that the email has valid format. qed.")
 			.as_ref(),
 	);
-	debug!("Found the following misc details: {:?}", my_misc);
+	debug!(
+		target: LOG_TARGET,
+		"Found the following misc details: {:?}", my_misc
+	);
 
 	// Create one future per lookup result.
 	let futures = my_mx

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@
 //! - Catch-all address. Is this email address a catch-all address?
 //!
 //! ```rust
-//! use check_if_email_exists::{check_emails, CheckEmailInput};
+//! use check_if_email_exists::{check_email, CheckEmailInput};
 //!
 //! async fn check() {
 //!     // Let's say we want to test the deliverability of someone@gmail.com.
@@ -47,7 +47,7 @@
 //!         .hello_name("example.org".into()); // Used in the `EHLO` command
 //!
 //!     // Verify this input, using async/await syntax.
-//!     let result = check_emails(&input).await;
+//!     let result = check_email(&input).await;
 //!
 //!     // `result` is a `Vec<CheckEmailOutput>`, where the CheckEmailOutput
 //!     // struct contains all information about one email.
@@ -75,13 +75,13 @@ use util::constants::LOG_TARGET;
 
 pub use util::input_output::*;
 
-/// Check a single emails. This assumes this `input.check_emails` contains
+/// Check a single emails. This assumes this `input.check_email` contains
 /// exactly one element. If it contains more, elements other than the first
 /// one will be ignored.
 ///
 /// # Panics
 ///
-/// This function panics if `input.check_emails` is empty.
+/// This function panics if `input.check_email` is empty.
 async fn check_single_email(input: CheckEmailInput) -> CheckEmailOutput {
 	let from_email = EmailAddress::from_str(input.from_email.as_ref()).unwrap_or_else(|_| {
 		warn!(
@@ -193,7 +193,7 @@ async fn check_single_email(input: CheckEmailInput) -> CheckEmailOutput {
 /// The main function of this library: takes as input a list of email addresses
 /// to check. Then performs syntax, mx, smtp and misc checks, and outputs a
 /// list of results.
-pub async fn check_emails(inputs: &CheckEmailInput) -> Vec<CheckEmailOutput> {
+pub async fn check_email(inputs: &CheckEmailInput) -> Vec<CheckEmailOutput> {
 	// FIXME Obviously, the below `join_all` is not optimal. Some optimizations
 	// include:
 	// - if multiple email addresses share the same domain, we should only do

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -58,10 +58,10 @@
 #[macro_use]
 extern crate log;
 
-pub mod misc;
-pub mod mx;
-pub mod smtp;
-pub mod syntax;
+mod misc;
+mod mx;
+mod smtp;
+mod syntax;
 mod util;
 
 use async_smtp::{smtp::SMTP_PORT, EmailAddress};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,11 +34,11 @@
 //! - Catch-all address. Is this email address a catch-all address?
 //!
 //! ```rust
-//! use check_if_email_exists::{email_exists, CheckEmailInput};
+//! use check_if_email_exists::{check_emails, CheckEmailInput};
 //!
 //! async fn check() {
 //!     // Let's say we want to test the deliverability of someone@gmail.com.
-//!     let mut input = CheckEmailInput::new("someone@gmail.com".into());
+//!     let mut input = CheckEmailInput::new(vec!["someone@gmail.com".into()]);
 //!
 //!     // Optionally, we can also tweak the configuration parameters used in the
 //!     // verification.
@@ -47,10 +47,10 @@
 //!         .hello_name("example.org".into()); // Used in the `EHLO` command
 //!
 //!     // Verify this input, using async/await syntax.
-//!     let result = email_exists(&input).await;
+//!     let result = check_emails(&input).await;
 //!
-//!     // `result` is a `CheckEmailOutput` struct containing all information about the
-//!     // email.
+//!     // `result` is a `Vec<CheckEmailOutput>`, where the CheckEmailOutput
+//!     // struct contains all information about one email.
 //!     println!("{:?}", result);
 //! }
 //! ```

--- a/core/src/misc.rs
+++ b/core/src/misc.rs
@@ -23,6 +23,14 @@ pub struct MiscDetails {
 	pub is_disposable: bool,
 }
 
+impl Default for MiscDetails {
+	fn default() -> Self {
+		MiscDetails {
+			is_disposable: false,
+		}
+	}
+}
+
 /// Error occured connecting to this email server via SMTP.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "message")]

--- a/core/src/misc.rs
+++ b/core/src/misc.rs
@@ -17,27 +17,27 @@
 use crate::syntax::SyntaxDetails;
 use serde::Serialize;
 
-/// Details that we gathered from connecting to this email via SMTP
+/// Details that we gathered from connecting to this email via SMTP.
 #[derive(Debug, Serialize)]
 pub struct MiscDetails {
 	/// Is this a DEA (disposable email account)?
 	pub is_disposable: bool,
 }
 
-/// Error occured connecting to this email server via SMTP
+/// Error occured connecting to this email server via SMTP.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "message")]
 pub enum MiscError {
-	/// Skipped checking SMTP details
+	/// Skipped checking SMTP details.
 	Skipped,
 }
 
-/// Fetch misc details about the email address, such as whether it's disposable
+/// Fetch misc details about the email address, such as whether it's disposable.
 pub fn misc_details(syntax: &SyntaxDetails) -> MiscDetails {
 	MiscDetails {
 		// mailchecker::is_valid checks also if the syntax is valid. But if
 		// we're here, it means we're sure the syntax is valid, so is_valid
-		// actually will only check the disposable email Misc.
+		// actually will only check if it's disposable.
 		is_disposable: !mailchecker::is_valid(syntax.address.to_string().as_ref()),
 	}
 }

--- a/core/src/misc.rs
+++ b/core/src/misc.rs
@@ -31,13 +31,12 @@ impl Default for MiscDetails {
 	}
 }
 
-/// Error occured connecting to this email server via SMTP.
+/// Error occured connecting to this email server via SMTP. Right now this
+/// enum has no variant, as `check_misc` cannot fail. But putting a placeholder
+/// right now to avoid future breaking changes.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "message")]
-pub enum MiscError {
-	/// Skipped checking SMTP details.
-	Skipped,
-}
+pub enum MiscError {}
 
 /// Fetch misc details about the email address, such as whether it's disposable.
 pub fn check_misc(address: &str) -> MiscDetails {

--- a/core/src/misc.rs
+++ b/core/src/misc.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::syntax::SyntaxDetails;
 use serde::Serialize;
 
 /// Details that we gathered from connecting to this email via SMTP.
@@ -33,11 +32,11 @@ pub enum MiscError {
 }
 
 /// Fetch misc details about the email address, such as whether it's disposable.
-pub fn misc_details(syntax: &SyntaxDetails) -> MiscDetails {
+pub fn check_misc(address: &str) -> MiscDetails {
 	MiscDetails {
 		// mailchecker::is_valid checks also if the syntax is valid. But if
 		// we're here, it means we're sure the syntax is valid, so is_valid
 		// actually will only check if it's disposable.
-		is_disposable: !mailchecker::is_valid(syntax.address.to_string().as_ref()),
+		is_disposable: !mailchecker::is_valid(address),
 	}
 }

--- a/core/src/mx.rs
+++ b/core/src/mx.rs
@@ -50,7 +50,7 @@ impl Serialize for MxDetails {
 			.unwrap_or_else(|_| vec![]); // In case of a resolve error, we don't serialize the error.
 
 		let mut map = serializer.serialize_map(Some(2))?;
-		map.serialize_entry("accepts_mail", &(records.len() > 0))?;
+		map.serialize_entry("accepts_mail", &records.is_empty())?;
 		map.serialize_entry("records", &records)?;
 		map.end()
 	}

--- a/core/src/mx.rs
+++ b/core/src/mx.rs
@@ -77,7 +77,7 @@ impl From<ResolveError> for MxError {
 }
 
 /// Make a MX lookup.
-pub async fn get_mx_lookup(syntax: &SyntaxDetails) -> Result<MxDetails, MxError> {
+pub async fn check_mx(syntax: &SyntaxDetails) -> Result<MxDetails, MxError> {
 	// Construct a new Resolver with default configuration options
 	let resolver =
 		TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()).await?;

--- a/core/src/mx.rs
+++ b/core/src/mx.rs
@@ -27,6 +27,14 @@ pub struct MxDetails {
 	pub lookup: Result<MxLookup, ResolveError>,
 }
 
+impl Default for MxDetails {
+	fn default() -> Self {
+		MxDetails {
+			lookup: Err(ResolveError::from("Skipped")),
+		}
+	}
+}
+
 impl From<MxLookup> for MxDetails {
 	fn from(lookup: MxLookup) -> Self {
 		MxDetails { lookup: Ok(lookup) }
@@ -60,8 +68,6 @@ impl Serialize for MxDetails {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "message")]
 pub enum MxError {
-	/// Skipped checking MX records.
-	Skipped,
 	/// Error with IO.
 	#[serde(serialize_with = "ser_with_display")]
 	IoError(Error),

--- a/core/src/mx.rs
+++ b/core/src/mx.rs
@@ -50,7 +50,7 @@ impl Serialize for MxDetails {
 			.unwrap_or_else(|_| vec![]); // In case of a resolve error, we don't serialize the error.
 
 		let mut map = serializer.serialize_map(Some(2))?;
-		map.serialize_entry("accepts_mail", &records.is_empty())?;
+		map.serialize_entry("accepts_mail", &!records.is_empty())?;
 		map.serialize_entry("records", &records)?;
 		map.end()
 	}

--- a/core/src/smtp.rs
+++ b/core/src/smtp.rs
@@ -36,6 +36,8 @@ use super::util::email_input::EmailInputProxy;
 /// Details that we gathered from connecting to this email via SMTP
 #[derive(Debug, Serialize)]
 pub struct SmtpDetails {
+	/// Are we able to connect to the SMTP server?
+	pub can_connect_smtp: bool,
 	/// Is this email account's inbox full?
 	pub has_full_inbox: bool,
 	/// Does this domain have a catch-all email address?
@@ -259,6 +261,8 @@ pub async fn smtp_details(
 	hello_name: &str,
 	proxy: &Option<EmailInputProxy>,
 ) -> Result<SmtpDetails, SmtpError> {
+	// FIXME If the SMTP is not connectable, we should actually return an
+	// Ok(SmtpDetails { can_connect_smtp: false, ... }).
 	let mut smtp_client = connect_to_host(from_email, host, port, hello_name, proxy).await?;
 
 	let is_catch_all = email_has_catch_all(&mut smtp_client, domain)
@@ -269,6 +273,7 @@ pub async fn smtp_details(
 	smtp_client.close().await?;
 
 	Ok(SmtpDetails {
+		can_connect_smtp: true,
 		has_full_inbox: deliverability.has_full_inbox,
 		is_catch_all,
 		is_deliverable: deliverability.is_deliverable,

--- a/core/src/smtp.rs
+++ b/core/src/smtp.rs
@@ -125,11 +125,10 @@ async fn connect_to_host(
 	}
 
 	// "MAIL FROM: user@example.org"
-	// FIXME Do not clone?
-	let from_email = from_email.clone();
 	try_smtp!(
 		smtp_client
-			.command(MailCommand::new(Some(from_email), vec![],))
+			// FIXME Do not clone?
+			.command(MailCommand::new(Some(from_email.clone()), vec![],))
 			.await,
 		smtp_client,
 		host,
@@ -252,7 +251,7 @@ async fn email_has_catch_all(
 }
 
 /// Get all email details we can.
-pub async fn smtp_details(
+pub async fn check_smtp(
 	from_email: &EmailAddress,
 	to_email: &EmailAddress,
 	host: &Name,

--- a/core/src/smtp.rs
+++ b/core/src/smtp.rs
@@ -46,16 +46,16 @@ pub struct SmtpDetails {
 	pub is_disabled: bool,
 }
 
-/// Error occured connecting to this email server via SMTP
+/// Error occured connecting to this email server via SMTP.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", content = "message")]
 pub enum SmtpError {
-	/// Skipped checking SMTP details
+	/// Skipped checking SMTP details.
 	Skipped,
-	/// Error if we're using a SOCKS5 proxy
+	/// Error if we're using a SOCKS5 proxy.
 	#[serde(serialize_with = "ser_with_display")]
 	SocksError(SocksError),
-	/// Error when communicating with SMTP server
+	/// Error when communicating with SMTP server.
 	#[serde(serialize_with = "ser_with_display")]
 	SmtpError(AsyncSmtpError),
 }
@@ -84,7 +84,7 @@ macro_rules! try_smtp (
     })
 );
 
-/// Attempt to connect to host via SMTP, and return SMTP client on success
+/// Attempt to connect to host via SMTP, and return SMTP client on success.
 async fn connect_to_host(
 	from_email: &EmailAddress,
 	host: &Name,
@@ -139,23 +139,22 @@ async fn connect_to_host(
 
 struct Deliverability {
 	/// Is this email account's inbox full?
-	pub has_full_inbox: bool,
+	has_full_inbox: bool,
 	/// Can we send an email to this address?
 	is_deliverable: bool,
 	/// Is the email blocked or disabled by the provider?
 	is_disabled: bool,
 }
 
-/// Check if `to_email` exists on host server with given port
+/// Check if `to_email` exists on host server with given port.
 async fn email_deliverable(
 	smtp_client: &mut SmtpTransport,
 	to_email: &EmailAddress,
 ) -> Result<Deliverability, SmtpError> {
 	// "RCPT TO: me@email.com"
 	// FIXME Do not clone?
-	let to_email = to_email.clone();
 	match smtp_client
-		.command(RcptCommand::new(to_email, vec![]))
+		.command(RcptCommand::new(to_email.clone(), vec![]))
 		.await
 	{
 		Ok(response) => match response.first_line() {
@@ -180,9 +179,9 @@ async fn email_deliverable(
 		Err(err) => {
 			let err_string = err.to_string();
 			// Don't return an error if the error contains anything about the
-			// address being undeliverable
+			// address being undeliverable.
 
-			// Check if the email account has been disabled or blocked
+			// Check if the email account has been disabled or blocked.
 			// e.g. "The email account that you tried to reach is disabled. Learn more at https://support.google.com/mail/?p=DisabledUser"
 			if err_string.contains("disabled") || err_string.contains("blocked") {
 				return Ok(Deliverability {
@@ -192,7 +191,7 @@ async fn email_deliverable(
 				});
 			}
 
-			// Check if the email account has a full inbox
+			// Check if the email account has a full inbox.
 			if err_string.contains("full")
 				|| err_string.contains("insufficient")
 				|| err_string.contains("over quota")
@@ -205,7 +204,7 @@ async fn email_deliverable(
 				});
 			}
 
-			// These are the possible error messages when email account doesn't exist
+			// These are the possible error messages when email account doesn't exist.
 			if err_string.contains("address rejected")
 				|| err_string.contains("does not exist")
 				|| err_string.contains("invalid address")
@@ -230,12 +229,12 @@ async fn email_deliverable(
 	}
 }
 
-/// Verify the existence of a catch-all email
+/// Verify the existence of a catch-all email.
 async fn email_has_catch_all(
 	smtp_client: &mut SmtpTransport,
 	domain: &str,
 ) -> Result<bool, SmtpError> {
-	// Create a random 15-char alphanumerical string
+	// Create a random 15-char alphanumerical string.
 	let random_email = rand::thread_rng()
 		.sample_iter(&Alphanumeric)
 		.take(15)

--- a/core/src/syntax.rs
+++ b/core/src/syntax.rs
@@ -22,13 +22,13 @@ use std::str::FromStr;
 /// Syntax information after parsing an email address
 #[derive(Debug, PartialEq, Serialize)]
 pub struct SyntaxDetails {
-	/// The email address as a async_smtp EmailAddress
+	/// The email address as a async_smtp `EmailAddress`.
 	pub address: EmailAddress,
-	/// The domain name, after "@"
+	/// The domain name, after "@".
 	pub domain: String,
 	/// Does the email have a valid syntax?
 	pub is_valid_syntax: bool,
-	/// The username, before "@"
+	/// The username, before "@".
 	pub username: String,
 }
 
@@ -52,7 +52,7 @@ impl PartialEq for SyntaxError {
 }
 
 /// From an `email_address` string, compute syntax information about it, such as
-/// username and domain
+/// username and domain.
 pub fn address_syntax(email_address: &str) -> Result<SyntaxDetails, SyntaxError> {
 	let email_address = match EmailAddress::from_str(email_address) {
 		Ok(m) => m,

--- a/core/src/syntax.rs
+++ b/core/src/syntax.rs
@@ -14,49 +14,39 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::util::ser_with_display::ser_with_display;
-use async_smtp::{error::Error as AsyncSmtpError, EmailAddress};
+use async_smtp::EmailAddress;
 use serde::Serialize;
 use std::str::FromStr;
 
 /// Syntax information after parsing an email address
 #[derive(Debug, PartialEq, Serialize)]
 pub struct SyntaxDetails {
-	/// The email address as a async_smtp `EmailAddress`.
-	pub address: EmailAddress,
-	/// The domain name, after "@".
+	/// The email address as a async_smtp `EmailAddress`. It will be `None` if
+	/// the email address is ill-formed.
+	pub address: Option<EmailAddress>,
+	/// The domain name, after "@". It will be the empty string if the email
+	/// address if ill-formed.
 	pub domain: String,
 	/// Does the email have a valid syntax?
 	pub is_valid_syntax: bool,
-	/// The username, before "@".
+	/// The username, before "@". It will be the empty string if the email
+	/// address if ill-formed.
 	pub username: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", content = "message")]
-pub enum SyntaxError {
-	#[serde(serialize_with = "ser_with_display")]
-	SyntaxError(AsyncSmtpError),
-}
-
-impl PartialEq for SyntaxError {
-	fn eq(&self, other: &Self) -> bool {
-		match (self, other) {
-			(
-				SyntaxError::SyntaxError(AsyncSmtpError::InvalidEmailAddress),
-				SyntaxError::SyntaxError(AsyncSmtpError::InvalidEmailAddress),
-			) => true,
-			_ => false,
-		}
-	}
 }
 
 /// From an `email_address` string, compute syntax information about it, such as
 /// username and domain.
-pub fn address_syntax(email_address: &str) -> Result<SyntaxDetails, SyntaxError> {
+pub fn check_syntax(email_address: &str) -> SyntaxDetails {
 	let email_address = match EmailAddress::from_str(email_address) {
 		Ok(m) => m,
-		Err(error) => return Err(SyntaxError::SyntaxError(error)),
+		_ => {
+			return SyntaxDetails {
+				address: None,
+				domain: "".into(),
+				is_valid_syntax: false,
+				username: "".into(),
+			}
+		}
 	};
 
 	let iter: &str = email_address.as_ref();
@@ -70,14 +60,12 @@ pub fn address_syntax(email_address: &str) -> Result<SyntaxDetails, SyntaxError>
 		.expect("We checked above that email is valid. qed.")
 		.into();
 
-	let address_details = SyntaxDetails {
-		address: email_address,
+	SyntaxDetails {
+		address: Some(email_address),
 		domain,
 		is_valid_syntax: true,
 		username,
-	};
-
-	Ok(address_details)
+	}
 }
 
 #[cfg(test)]
@@ -85,35 +73,41 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn should_return_error_for_invalid_email() {
+	fn should_return_invalid_for_invalid_email() {
 		assert_eq!(
-			address_syntax("foo"),
-			Err(SyntaxError::SyntaxError(
-				AsyncSmtpError::InvalidEmailAddress
-			))
+			check_syntax("foo"),
+			SyntaxDetails {
+				address: None,
+				domain: "".into(),
+				is_valid_syntax: false,
+				username: "".into(),
+			}
 		);
 	}
 
 	#[test]
-	fn should_return_error_for_invalid_email_with_at() {
+	fn should_return_invalid_for_invalid_email_with_at() {
 		assert_eq!(
-			address_syntax("foo@bar"),
-			Err(SyntaxError::SyntaxError(
-				AsyncSmtpError::InvalidEmailAddress
-			))
+			check_syntax("foo@bar"),
+			SyntaxDetails {
+				address: None,
+				domain: "".into(),
+				is_valid_syntax: false,
+				username: "".into(),
+			}
 		);
 	}
 
 	#[test]
 	fn should_work_for_valid_email() {
 		assert_eq!(
-			address_syntax("foo@bar.com"),
-			Ok(SyntaxDetails {
-				address: EmailAddress::new("foo@bar.com".into()).unwrap(),
+			check_syntax("foo@bar.com"),
+			SyntaxDetails {
+				address: Some(EmailAddress::new("foo@bar.com".into()).unwrap()),
 				domain: "bar.com".into(),
 				is_valid_syntax: true,
 				username: "foo".into(),
-			})
+			}
 		);
 	}
 }

--- a/core/src/syntax.rs
+++ b/core/src/syntax.rs
@@ -34,6 +34,17 @@ pub struct SyntaxDetails {
 	pub username: String,
 }
 
+impl Default for SyntaxDetails {
+	fn default() -> Self {
+		SyntaxDetails {
+			address: None,
+			domain: "".into(),
+			is_valid_syntax: false,
+			username: "".into(),
+		}
+	}
+}
+
 /// From an `email_address` string, compute syntax information about it, such as
 /// username and domain.
 pub fn check_syntax(email_address: &str) -> SyntaxDetails {

--- a/core/src/util/constants.rs
+++ b/core/src/util/constants.rs
@@ -14,6 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod constants;
-pub mod input;
-pub mod ser_with_display;
+pub const LOG_TARGET: &str = "check-if-email-exists";

--- a/core/src/util/input.rs
+++ b/core/src/util/input.rs
@@ -16,7 +16,7 @@
 
 /// Perform the email verification via a specified proxy. The usage of a proxy
 /// is optional.
-pub struct EmailInputProxy {
+pub struct CheckEmailInputProxy {
 	/// Use the specified SOCKS5 proxy host to perform email verification.
 	pub host: String,
 	/// Use the specified SOCKS5 proxy port to perform email verification.
@@ -25,7 +25,7 @@ pub struct EmailInputProxy {
 
 /// Builder pattern for the input argument into the main `email_exists`
 /// function.
-pub struct EmailInput {
+pub struct CheckEmailInput {
 	/// The email to validate.
 	pub to_email: String,
 	/// Email to use in the `MAIL FROM:` SMTP command.
@@ -38,13 +38,13 @@ pub struct EmailInput {
 	pub hello_name: String,
 	/// Perform the email verification via a specified proxy. The usage of a
 	/// proxy is optional.
-	pub proxy: Option<EmailInputProxy>,
+	pub proxy: Option<CheckEmailInputProxy>,
 }
 
-impl EmailInput {
-	/// Create a new EmailInput.
-	pub fn new(email: String) -> EmailInput {
-		EmailInput {
+impl CheckEmailInput {
+	/// Create a new CheckEmailInput.
+	pub fn new(email: String) -> CheckEmailInput {
+		CheckEmailInput {
 			to_email: email,
 			from_email: "user@example.org".into(),
 			hello_name: "localhost".into(),
@@ -53,20 +53,20 @@ impl EmailInput {
 	}
 
 	/// Set the email to use in the `MAIL FROM:` SMTP command.
-	pub fn from_email(&mut self, email: String) -> &mut EmailInput {
+	pub fn from_email(&mut self, email: String) -> &mut CheckEmailInput {
 		self.from_email = email;
 		self
 	}
 
 	/// Set the name to use in the `EHLO:` SMTP command.
-	pub fn hello_name(&mut self, name: String) -> &mut EmailInput {
+	pub fn hello_name(&mut self, name: String) -> &mut CheckEmailInput {
 		self.hello_name = name;
 		self
 	}
 
 	/// Use the specified proxy to perform email verification.
-	pub fn proxy(&mut self, proxy_host: String, proxy_port: u16) -> &mut EmailInput {
-		self.proxy = Some(EmailInputProxy {
+	pub fn proxy(&mut self, proxy_host: String, proxy_port: u16) -> &mut CheckEmailInput {
+		self.proxy = Some(CheckEmailInputProxy {
 			host: proxy_host,
 			port: proxy_port,
 		});

--- a/core/src/util/input.rs
+++ b/core/src/util/input.rs
@@ -16,6 +16,7 @@
 
 /// Perform the email verification via a specified proxy. The usage of a proxy
 /// is optional.
+#[derive(Debug, Clone)]
 pub struct CheckEmailInputProxy {
 	/// Use the specified SOCKS5 proxy host to perform email verification.
 	pub host: String,
@@ -25,9 +26,10 @@ pub struct CheckEmailInputProxy {
 
 /// Builder pattern for the input argument into the main `email_exists`
 /// function.
+#[derive(Debug, Clone)]
 pub struct CheckEmailInput {
 	/// The email to validate.
-	pub to_email: String,
+	pub to_emails: Vec<String>,
 	/// Email to use in the `MAIL FROM:` SMTP command.
 	///
 	/// Defaults to "user@example.org".
@@ -43,9 +45,9 @@ pub struct CheckEmailInput {
 
 impl CheckEmailInput {
 	/// Create a new CheckEmailInput.
-	pub fn new(email: String) -> CheckEmailInput {
+	pub fn new(to_emails: Vec<String>) -> CheckEmailInput {
 		CheckEmailInput {
-			to_email: email,
+			to_emails,
 			from_email: "user@example.org".into(),
 			hello_name: "localhost".into(),
 			proxy: None,

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -14,5 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod email_input;
+pub mod input;
 pub mod ser_with_display;

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -15,5 +15,5 @@
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod constants;
-pub mod input;
+pub mod input_output;
 pub mod ser_with_display;

--- a/core/src/util/ser_with_display.rs
+++ b/core/src/util/ser_with_display.rs
@@ -17,7 +17,7 @@
 use serde::Serializer;
 use std::fmt::Display;
 
-/// Implement the `Serialize` trait for types that are `Display`
+/// Implement the `Serialize` trait for types that are `Display`.
 /// https://stackoverflow.com/questions/58103801/serialize-using-the-display-trait
 pub fn ser_with_display<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -31,7 +31,7 @@ args:
       long: proxy-host
       takes_value: true
   - PROXY_PORT:
-      default_value: '1080'
+      default_value: "1080"
       help: Use the specified SOCKS5 proxy port to perform email verification. Only used when `--proxy-host` flag is set.
       long: proxy-port
       takes_value: true

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-use check_if_email_exists::{email_exists, EmailInput};
+use check_if_email_exists::{check_email, EmailInput};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -60,7 +60,7 @@ async fn req_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
 			let mut input = EmailInput::new(body.to_email);
 			input.from_email(body.from_email.unwrap_or_else(|| "user@example.org".into())).hello_name(body.hello_name.unwrap_or_else(|| "localhost".into()));
 
-			let body = email_exists(&input).await;
+			let body = check_email(&input).await;
 			let body = match serde_json::to_string(&body) {
 				Ok(b) => b,
 				Err(err) => {

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-use check_if_email_exists::{check_email, EmailInput};
+use check_if_email_exists::{check_emails, CheckEmailInput};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -25,8 +25,8 @@ use std::net::SocketAddr;
 pub struct PostReqBody {
 	from_email: Option<String>,
 	hello_name: Option<String>,
-	to_email: String,
-	// TODO Add fields for proxy
+	to_email: Vec<String>,
+	// FIXME Add fields for proxy
 }
 
 /// Error Response from POST /
@@ -57,10 +57,10 @@ async fn req_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
 			};
 
 			// Create EmailInput from body
-			let mut input = EmailInput::new(body.to_email);
+			let mut input = CheckEmailInput::new(body.to_email);
 			input.from_email(body.from_email.unwrap_or_else(|| "user@example.org".into())).hello_name(body.hello_name.unwrap_or_else(|| "localhost".into()));
 
-			let body = check_email(&input).await;
+			let body = check_emails(&input).await;
 			let body = match serde_json::to_string(&body) {
 				Ok(b) => b,
 				Err(err) => {

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with check-if-email-exists.  If not, see <http://www.gnu.org/licenses/>.
 
-use check_if_email_exists::{check_emails, CheckEmailInput};
+use check_if_email_exists::{check_email, CheckEmailInput};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -60,7 +60,7 @@ async fn req_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
 			let mut input = CheckEmailInput::new(body.to_email);
 			input.from_email(body.from_email.unwrap_or_else(|| "user@example.org".into())).hello_name(body.hello_name.unwrap_or_else(|| "localhost".into()));
 
-			let body = check_emails(&input).await;
+			let body = check_email(&input).await;
 			let body = match serde_json::to_string(&body) {
 				Ok(b) => b,
 				Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ extern crate tokio;
 
 mod http;
 
-use check_if_email_exists::{check_email, EmailInput};
+use check_if_email_exists::{check_emails, CheckEmailInput};
 use clap::{crate_version, value_t, App};
 use std::env;
 
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 			.value_of("HELLO_NAME")
 			.expect("HELLO_NAME has a default value. qed.");
 
-		let mut input = EmailInput::new(to_email.into());
+		let mut input = CheckEmailInput::new(vec![to_email.into()]);
 		input
 			.from_email(from_email.into())
 			.hello_name(hello_name.into());
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 			input.proxy(proxy_host.into(), proxy_port);
 		}
 
-		let result = check_email(&input).await;
+		let result = check_emails(&input).await;
 
 		match serde_json::to_string_pretty(&result) {
 			Ok(output) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ extern crate tokio;
 
 mod http;
 
-use check_if_email_exists::{email_exists, EmailInput};
+use check_if_email_exists::{check_email, EmailInput};
 use clap::{crate_version, value_t, App};
 use std::env;
 
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 			input.proxy(proxy_host.into(), proxy_port);
 		}
 
-		let result = email_exists(&input).await;
+		let result = check_email(&input).await;
 
 		match serde_json::to_string_pretty(&result) {
 			Ok(output) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ extern crate tokio;
 
 mod http;
 
-use check_if_email_exists::{check_emails, CheckEmailInput};
+use check_if_email_exists::{check_email, CheckEmailInput};
 use clap::{crate_version, value_t, App};
 use std::env;
 
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 			input.proxy(proxy_host.into(), proxy_port);
 		}
 
-		let result = check_emails(&input).await;
+		let result = check_email(&input).await;
 
 		match serde_json::to_string_pretty(&result) {
 			Ok(output) => {

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-if-email-exists-test-suite"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2018"
 publish = false
 

--- a/test_suite/src/fixtures/foo.json
+++ b/test_suite/src/fixtures/foo.json
@@ -1,0 +1,12 @@
+{
+	"input": "foo",
+	"misc": { "error": { "type": "Skipped" } },
+	"mx": { "error": { "type": "Skipped" } },
+	"smtp": { "error": { "type": "Skipped" } },
+	"syntax": {
+		"address": null,
+		"domain": "",
+		"is_valid_syntax": false,
+		"username": ""
+	}
+}

--- a/test_suite/src/fixtures/foo.json
+++ b/test_suite/src/fixtures/foo.json
@@ -1,8 +1,14 @@
 {
 	"input": "foo",
-	"misc": { "error": { "type": "Skipped" } },
-	"mx": { "error": { "type": "Skipped" } },
-	"smtp": { "error": { "type": "Skipped" } },
+	"misc": { "is_disposable": false },
+	"mx": { "accepts_mail": false, "records": [] },
+	"smtp": {
+		"can_connect_smtp": false,
+		"has_full_inbox": false,
+		"is_catch_all": false,
+		"is_deliverable": false,
+		"is_disabled": false
+	},
 	"syntax": {
 		"address": null,
 		"domain": "",

--- a/test_suite/src/fixtures/foo@bar.baz.json
+++ b/test_suite/src/fixtures/foo@bar.baz.json
@@ -1,0 +1,12 @@
+{
+	"input": "foo@bar.baz",
+	"misc": { "error": { "type": "Skipped" } },
+	"mx": { "accepts_mail": false, "records": [] },
+	"smtp": { "error": { "type": "Skipped" } },
+	"syntax": {
+		"address": "foo@bar.baz",
+		"domain": "bar.baz",
+		"is_valid_syntax": true,
+		"username": "foo"
+	}
+}

--- a/test_suite/src/fixtures/foo@bar.baz.json
+++ b/test_suite/src/fixtures/foo@bar.baz.json
@@ -1,8 +1,14 @@
 {
 	"input": "foo@bar.baz",
-	"misc": { "error": { "type": "Skipped" } },
+	"misc": { "is_disposable": false },
 	"mx": { "accepts_mail": false, "records": [] },
-	"smtp": { "error": { "type": "Skipped" } },
+	"smtp": {
+		"can_connect_smtp": false,
+		"has_full_inbox": false,
+		"is_catch_all": false,
+		"is_deliverable": false,
+		"is_disabled": false
+	},
 	"syntax": {
 		"address": "foo@bar.baz",
 		"domain": "bar.baz",

--- a/test_suite/src/fixtures/foo@bar.json
+++ b/test_suite/src/fixtures/foo@bar.json
@@ -1,0 +1,12 @@
+{
+	"input": "foo@bar",
+	"misc": { "error": { "type": "Skipped" } },
+	"mx": { "error": { "type": "Skipped" } },
+	"smtp": { "error": { "type": "Skipped" } },
+	"syntax": {
+		"address": null,
+		"domain": "",
+		"is_valid_syntax": false,
+		"username": ""
+	}
+}

--- a/test_suite/src/fixtures/foo@bar.json
+++ b/test_suite/src/fixtures/foo@bar.json
@@ -1,8 +1,14 @@
 {
 	"input": "foo@bar",
-	"misc": { "error": { "type": "Skipped" } },
-	"mx": { "error": { "type": "Skipped" } },
-	"smtp": { "error": { "type": "Skipped" } },
+	"misc": { "is_disposable": false },
+	"mx": { "accepts_mail": false, "records": [] },
+	"smtp": {
+		"can_connect_smtp": false,
+		"has_full_inbox": false,
+		"is_catch_all": false,
+		"is_deliverable": false,
+		"is_disabled": false
+	},
 	"syntax": {
 		"address": null,
 		"domain": "",

--- a/test_suite/src/fixtures/someone@gmail.com.json
+++ b/test_suite/src/fixtures/someone@gmail.com.json
@@ -4,11 +4,11 @@
 	"mx": {
 		"accepts_mail": true,
 		"records": [
-			"alt3.gmail-smtp-in.l.google.com.",
-			"gmail-smtp-in.l.google.com.",
 			"alt4.gmail-smtp-in.l.google.com.",
+			"alt1.gmail-smtp-in.l.google.com.",
 			"alt2.gmail-smtp-in.l.google.com.",
-			"alt1.gmail-smtp-in.l.google.com."
+			"gmail-smtp-in.l.google.com.",
+			"alt3.gmail-smtp-in.l.google.com."
 		]
 	},
 	"smtp": {

--- a/test_suite/src/fixtures/someone@gmail.com.json
+++ b/test_suite/src/fixtures/someone@gmail.com.json
@@ -1,0 +1,27 @@
+{
+	"input": "someone@gmail.com",
+	"misc": { "is_disposable": false },
+	"mx": {
+		"accepts_mail": true,
+		"records": [
+			"alt3.gmail-smtp-in.l.google.com.",
+			"gmail-smtp-in.l.google.com.",
+			"alt4.gmail-smtp-in.l.google.com.",
+			"alt2.gmail-smtp-in.l.google.com.",
+			"alt1.gmail-smtp-in.l.google.com."
+		]
+	},
+	"smtp": {
+		"can_connect_smtp": true,
+		"has_full_inbox": false,
+		"is_catch_all": false,
+		"is_deliverable": false,
+		"is_disabled": true
+	},
+	"syntax": {
+		"address": "someone@gmail.com",
+		"domain": "gmail.com",
+		"is_valid_syntax": true,
+		"username": "someone"
+	}
+}

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -48,7 +48,7 @@ mod tests {
 			let actual = serde_json::to_value(&result[0]).unwrap();
 
 			// Uncomment to see the JSON result of `check_emails`.
-			// println!("{}", actual);
+			println!("{}", actual);
 
 			// For the input,misc,smtp,syntax fields, we match exact JSON.
 			assert_eq!(expected.get("input"), actual.get("input"),);

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -18,14 +18,14 @@
 
 #[cfg(test)]
 mod tests {
-	use check_if_email_exists::{email_exists, EmailInput};
+	use check_if_email_exists::{check_email, EmailInput};
 	use tokio::runtime::Runtime;
 
 	#[test]
 	fn should_output_error_for_invalid_email() {
 		let result = Runtime::new()
 			.unwrap()
-			.block_on(email_exists(&EmailInput::new("foo".to_string())));
+			.block_on(check_email(&EmailInput::new("foo".to_string())));
 		assert_eq!(
 			serde_json::to_string(&result).unwrap(),
 			"{\"input\":\"foo\",\"misc\":{\"error\":{\"type\":\"Skipped\"}},\"mx\":{\"error\":{\"type\":\"Skipped\"}},\"smtp\":{\"error\":{\"type\":\"Skipped\"}},\"syntax\":{\"error\":{\"type\":\"SyntaxError\",\"message\":\"invalid email address\"}}}"
@@ -37,7 +37,7 @@ mod tests {
 	fn should_output_error_for_invalid_mx() {
 		let result = Runtime::new()
 			.unwrap()
-			.block_on(email_exists(&EmailInput::new("foo@bar.baz".to_string())));
+			.block_on(check_email(&EmailInput::new("foo@bar.baz".to_string())));
 
 		assert_eq!(
 			serde_json::to_string(&result).unwrap(),

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -42,13 +42,12 @@ mod tests {
 			let expected: serde_json::Value = serde_json::from_reader(file).unwrap();
 
 			println!("Check {}", filename);
-			let mut input = CheckEmailInput::new(vec![filename.into()]);
-			input.proxy("127.0.0.1".into(), 9050);
+			let input = CheckEmailInput::new(vec![filename.into()]);
 			let result = runtime.block_on(check_emails(&input));
 			let actual = serde_json::to_value(&result[0]).unwrap();
 
 			// Uncomment to see the JSON result of `check_emails`.
-			println!("{}", actual);
+			// println!("{}", actual);
 
 			// For the input,misc,smtp,syntax fields, we match exact JSON.
 			assert_eq!(expected.get("input"), actual.get("input"),);

--- a/test_suite/src/lib.rs
+++ b/test_suite/src/lib.rs
@@ -18,7 +18,7 @@
 
 #[cfg(test)]
 mod tests {
-	use check_if_email_exists::{check_emails, CheckEmailInput};
+	use check_if_email_exists::{check_email, CheckEmailInput};
 	use serde_json;
 	use std::fs;
 	use tokio::runtime::Runtime;
@@ -29,7 +29,7 @@ mod tests {
 		let paths = fs::read_dir(folder).unwrap();
 
 		// For every fixture file, we compare:
-		// - the result of `check_emails` with the email in the filename
+		// - the result of `check_email` with the email in the filename
 		// - the contents of the file
 		for path in paths {
 			let path = path.unwrap().path();
@@ -43,10 +43,10 @@ mod tests {
 
 			println!("Check {}", filename);
 			let input = CheckEmailInput::new(vec![filename.into()]);
-			let result = runtime.block_on(check_emails(&input));
+			let result = runtime.block_on(check_email(&input));
 			let actual = serde_json::to_value(&result[0]).unwrap();
 
-			// Uncomment to see the JSON result of `check_emails`.
+			// Uncomment to see the JSON result of `check_email`.
 			// println!("{}", actual);
 
 			// For the input,misc,smtp,syntax fields, we match exact JSON.


### PR DESCRIPTION
BREAKING CHANGE:

This new version includes an overhaul of the codebase, mainly to prepare the groundwork for the upcoming work on bulk validation. These changes include:

- The main function `email_exists` has been renamed to `check_email`:

```diff
- email_exists(&input).await;
+ check_email(&input).await;
```

- The input `EmailInput` has been renamed to `CheckEmailInput`. Its `::new()` method, instead of taking a single `String`, now takes `Vec<String>`.

- The output `SingleEmail` has been renamed to `CheckEmailOutput`. The main function `check_emails` now returns a `Vec<CheckEmailOutput>`.

```rust
pub async fn check_email(inputs: &CheckEmailInput) -> Vec<CheckEmailOutput>
```

- The `syntax` field in `CheckEmailOutput` is no longer a `Result<SyntaxDetails, SyntaxError>`, but only `SyntaxDetails`. Error cases are guaranteed not to happen for syntax validation.

- The `misc`, `mx`, and `smtp` fields' signatures stay the same: `Result<{Misc,Mx,Smtp}Details, {Misc,Mx,Smtp}Error>`. However, the `Result` is an `Err` only when an internal error arrives. In case of errors due to user input (e.g. incorrect email inputted), the `Default` trait has been implemented on `{Misc,Mx,Smtp}Details` and will be returned. As such, the `Skipped` variant of error enums has been removed.

```diff
{
  "input": "foo@bar.baz",
  "mx": {
-    "error": { "cannot resolve" }
+    "accepts_mail": false, // This is Default
+    "records": [] // This is Default
  }
```

- The `misc`, `mx`, `smtp`, `syntax` modules have been made private.