### PR TITLE
Check deliverability using successful response code instead of message parsing

### DIFF
--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -199,8 +199,9 @@ async fn email_deliverable(
 		.await
 	{
 		Ok(_) => {
-			// According to RFC 5321, `RCPT TO` command succeeds only with
-			// 250 and 251 codes: https://tools.ietf.org/html/rfc5321#page-56
+			// According to RFC 5321, `RCPT TO` command succeeds with 250 and
+			// 251 codes only (no 3xx codes at all):
+			// https://tools.ietf.org/html/rfc5321#page-56
 			//
 			// Where the 251 code is used for forwarding, which is not our case,
 			// because we always deliver to the SMTP server hosting the address


### PR DESCRIPTION
Fixes #771 

This PR makes deliverability check by checking the response code to be successfult for a `RCPT TO` command. The whole reasoning is described in the source code:

> According to [RFC 5321], [`RCPT TO` command][RCPT TO] succeeds only with `250` and `251` codes: <https://tools.ietf.org/html/rfc5321#page-56>
> 
> Where the `251` code is used for forwarding, which is not our case, because we always deliver to the SMTP server hosting the address itself.
> 
> So, if [`response.is_positive()`][2] (which is [a condition for returning `Ok`][1] from the `command()` method above), then delivery succeeds, accordingly to [RFC 5321].


[RFC 5321]: https://tools.ietf.org/html/rfc5321
[RCPT TO]: https://tools.ietf.org/html/rfc5321#section-4.1.1.3
[1]: https://docs.rs/async-smtp/0.3.4/src/async_smtp/smtp/client/inner.rs.html#260-262
[2]: https://docs.rs/async-smtp/0.3.4/src/async_smtp/smtp/response.rs.html#168-173